### PR TITLE
Quick fix reset em data

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"key": "reset-em-data",
-			"name": "<b>Reset module data</b> <i>Warning: This action cannot be undone. <br/>",
+			"name": "<b>Reset module data</b><br><i>Warning: This action cannot be undone",
 			"type": "button",
 			"url":
 			{

--- a/config.json
+++ b/config.json
@@ -36,6 +36,16 @@
 			"key": "import-from",
 			"name": "Sender email (by default <b>noreply@vumc.org</b>)",
 			"type": "text"
+		},
+		{
+			"key": "reset-em-data",
+			"name": "<b>Reset module data</b> <i>Warning: This action cannot be undone. <br/>",
+			"type": "button",
+			"url":
+			{
+				"name": "Reset",
+				"value": "resetModuleData.php"
+			}
 		}
 	],
 	"compatibility": {

--- a/css/style.css
+++ b/css/style.css
@@ -26,6 +26,9 @@
 .fa-times,.fa-exclamation-circle, .fa-ban{
     color: red;
 }
+
+.fa-stack { font-size: 0.5em; }
+
 .warning{
     color:#ffd24d !important;
 }

--- a/resetModuleData.php
+++ b/resetModuleData.php
@@ -5,19 +5,19 @@
 
 $settings = $module->getProjectSettings();
 
+# Ignore settings that are not relevant
 unset($settings["enabled"]);
 unset($settings["version"]);
 unset($settings["import-email"]);
 unset($settings["import-from"]);
 
+# Remove project setting with specified key from current project
 foreach ($settings as $key => $value) {
-    // Removes project setting with specified key from current project
     $module->removeProjectSetting($key);
 }
 
+# Send response and log 
 $icon = '<span class="fa-stack fa-2x"><i class="fas fa-circle fa-stack-2x"></i><i class="fas fa-redo fa-stack-1x fa-inverse"></i></span>';
-
-
 $logtext = "The module has been reset. {$icon}</div>";
 
 $module->log($logtext);
@@ -26,7 +26,5 @@ echo json_encode(array(
     'status' => 'success',
     'message' => $logtext
 ));
-
-
 
 ?>

--- a/resetModuleData.php
+++ b/resetModuleData.php
@@ -11,6 +11,16 @@ unset($settings["version"]);
 unset($settings["import-email"]);
 unset($settings["import-from"]);
 
+$num = count($settings);
+
+if($num == 0) {
+    echo json_encode(array(
+        'status' => 'warning',
+        'message' => 'There is no module data yet to be reset.'
+    ));
+    exit();
+}
+
 # Remove project setting with specified key from current project
 foreach ($settings as $key => $value) {
     $module->removeProjectSetting($key);
@@ -21,10 +31,11 @@ $icon = '<span class="fa-stack fa-2x"><i class="fas fa-circle fa-stack-2x"></i><
 $logtext = "The module has been reset. {$icon}</div>";
 
 $module->log($logtext);
+$message = 'Reset was successful. '.$num.' rows have been reset.';
 
 echo json_encode(array(
     'status' => 'success',
-    'message' => $logtext
+    'message' => $message
 ));
 
 ?>

--- a/resetModuleData.php
+++ b/resetModuleData.php
@@ -1,0 +1,32 @@
+<?php
+/** @var \Vanderbilt\BigDataImportExternalModule $module 
+ * 
+ */
+
+$settings = $module->getProjectSettings();
+
+unset($settings["enabled"]);
+unset($settings["version"]);
+unset($settings["import-email"]);
+unset($settings["import-from"]);
+
+foreach ($settings as $key => $value) {
+    // Removes project setting with specified key from current project
+    $module->removeProjectSetting($key);
+}
+
+$icon = '<span class="fa-stack fa-2x"><i class="fas fa-circle fa-stack-2x"></i><i class="fas fa-redo fa-stack-1x fa-inverse"></i></span>';
+
+
+$logtext = "The module has been reset. {$icon}</div>";
+
+$module->log($logtext);
+
+echo json_encode(array(
+    'status' => 'success',
+    'message' => $logtext
+));
+
+
+
+?>


### PR DESCRIPTION
Is a quick-fix for https://github.com/vanderbilt-redcap/big-data-import/issues/7. 

Adds a button into module configuration on project level that resets module data for the current project, without disabling the module or losing other settings (e.g. email address).

We would be very happy if you could enable this workaround asap, since we are very dependent on the big-data-import and it is stuck in some projects.